### PR TITLE
Fix did not work monitor reaction_added RTM

### DIFF
--- a/lib/slappy/event.rb
+++ b/lib/slappy/event.rb
@@ -26,7 +26,7 @@ module Slappy
     end
 
     def ts
-      Time.at(@data['ts'].to_f)
+      Time.at((@data['ts'] || @data['event_ts']).to_f)
     end
 
     def reply(text, options = {})


### PR DESCRIPTION
## Problem

This code does not run.

```
monitor 'reaction_added' do |event|
  puts event
end
```

## Cause

Invalid `time_valid?` 

The event data has `['event_ts']` not `['ts']`
https://api.slack.com/events/reaction_added

and 

```
irb(main):001:0> nil.to_f
=> 0.0
irb(main):002:0> Time.at(nil.to_f).nil?
=> false
```